### PR TITLE
Order dependencies for release

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "test"]
- :deps {org.babashka/cli {:mvn/version "0.4.39"}}
+ :deps {org.babashka/cli {:mvn/version "0.4.39"}
+        com.stuartsierra/dependency {:mvn/version "1.0.0"}}
 
  :tasks {migrate {:doc "Import existing Clojure library with git history. Use: bb migrate LIBRARY_PATH TARGET_REPO GROUP"
                   :requires ([migrate-library])

--- a/src/generate_ci_config.clj
+++ b/src/generate_ci_config.clj
@@ -38,7 +38,7 @@
      (vector
        (format "      - run:")
        (format "          name: Compile Node tests for %s" library)
-       (format "          command: cd %s && clojure -A:dev:shadow-cljs:local-deps compile test-node" library)
+       (format "          command: cd %s && clojure -A:dev:test:shadow-cljs:local-deps compile test-node" library)
        (format "      - run:")
        (format "          name: ⭐Run Node tests for %s" library)
        (format "          command: cd %s && node out/node-tests.js" library)))
@@ -46,7 +46,7 @@
      (vector
        (format "      - run:")
        (format "          name: Compile Browser tests for %s" library)
-       (format "          command: cd %s && clojure -A:dev:shadow-cljs:local-deps compile test-ci" library)
+       (format "          command: cd %s && clojure -A:dev:test:shadow-cljs:local-deps compile test-ci" library)
        (format "      - run:")
        (format "          name: ⭐Run Browser (karma) tests for %s" library)
        (format "          command: CHROME_BIN=`which chromium-browser` cd %s && npx karma start karma.conf.js --single-run" library)))])

--- a/src/generate_ci_config.clj
+++ b/src/generate_ci_config.clj
@@ -153,7 +153,9 @@
         version-tracking-timestamp (last-commit-timestamp version-tracking-path repo-root)
         library-source-paths (collect-libraries (:groups (get-config)) repo-root)
         libraries-source-timestamps (map #(vector (last-commit-timestamp % repo-root) %) (map #(relativize-path repo-root %) library-source-paths))
-        libraries-from-tracking (:libs latest-version)
+        libraries-from-tracking (-> (:libs latest-version)
+                                    (helpers/grouped-libs->libs-deps-map repo-root)
+                                    (helpers/order-libs-for-release))
         newest-source-change-timestamp (if (empty? libraries-source-timestamps)
                                          [-1]
                                          (reduce max (map first libraries-source-timestamps)))

--- a/src/release.clj
+++ b/src/release.clj
@@ -21,8 +21,7 @@
     (b/write-pom {:class-dir class-dir
                   :lib artefact-id
                   :version version
-                  :basis (b/create-basis {:project (subdir (first lib-paths) "deps.edn")
-                                          :aliases [:local-deps]})
+                  :basis (b/create-basis {:project (subdir (first lib-paths) "deps.edn")})
                   :src-dirs src-dirs})
     (b/copy-dir {:src-dirs src-dirs
                  :target-dir class-dir})

--- a/src/update_library_versions.clj
+++ b/src/update_library_versions.clj
@@ -145,8 +145,8 @@
         version-info {:created-at (current-timestamp)
                       :version version
                       :description "placeholder"
-                      :libs updated-libraries}
-        updated-version-tracking (conj previous-details version-info)]
+                      :libs (into [] updated-libraries)}
+        updated-version-tracking (into [] (concat [version-info] previous-details))]
     (helpers/write-edn updated-version-tracking version-tracking-path)))
 
 (defn update-deps-at-path

--- a/test/script_helpers_test.clj
+++ b/test/script_helpers_test.clj
@@ -14,3 +14,34 @@
       (is (= "district0x" (helpers/guess-group-id lib-version-file-path)))
       (is (= "io.bithub.district0x" (helpers/guess-group-id lib-version-build-path)))
       (is (= "io.github.district0x" (helpers/guess-group-id "/non-existent"))))))
+
+(defn is< [coll val-a val-b]
+  (let [coll-vector (into [] coll)]
+    (is (< (.indexOf coll-vector val-a) (.indexOf coll-vector val-b))
+        (format "  -> 🐛%s must come before %s" val-a val-b))))
+
+(deftest deps-ordering-tests
+  (testing "order libs based on their interdependence"
+    (let [ordering ["shared/cljs-web3-next"
+
+                    "server/district-server-web3"
+                    "server/district-server-smart-contracts"
+
+                    "browser/district-ui-web3"
+                    "browser/district-ui-smart-contracts"
+                    "browser/district-ui-bundle"]
+          deps {"server/district-server-smart-contracts" {:deps {'is.d0x/cljs-web3-next {:mvn/version "42"}
+                                                                 'is.d0x/district-server-web3 {:mvn/version "42"}}}
+                "server/district-server-web3" {:deps {'is.d0x/cljs-web3-next {:mvn/version "42"}}}
+
+                "browser/district-ui-web3" {:deps {'is.d0x/cljs-web3-next {:mvn/version "42"}}}
+                "browser/district-ui-smart-contracts" {:deps {'is.d0x/cljs-web3-next {:mvn/version "42"}
+                                                              'is.d0x/district-ui-web3 {:mvn/version "42"}}}
+                "shared/cljs-web3-next" {:deps {}}
+                "browser/district-ui-bundle" {:deps {'is.d0x/district-ui-web3 {:mvn/version "42"}
+                                                     'is.d0x/district-ui-smart-contracts {:mvn/version "42"}}}}
+          ordered (helpers/order-libs-for-release deps)]
+      (is (= "shared/cljs-web3-next" (first ordered)))
+      (is< ordered "server/district-server-web3" "server/district-server-smart-contracts")
+      (is< ordered "browser/district-ui-web3" "browser/district-ui-smart-contracts")
+      (is< ordered "browser/district-ui-smart-contracts" "browser/district-ui-bundle"))))


### PR DESCRIPTION
When library A depends on B, B must be released first, so that its `deps.edn` can reference an existing version on Clojars (maven checks & fetches it to find out about dependencies).

This change creates a DAG (directed acyclic graph) of all the dependencies included in the release and orders them topologically. That way non-dependent libraries get released first. And the ones depended on get released before the ones that depend on them

> Alternatively the deps could be released to a local repository (`~/.m2`) but that could be confusing on CI