### PR TITLE
Add version to POM to be able to publish to clojars

### DIFF
--- a/src/release.clj
+++ b/src/release.clj
@@ -22,7 +22,11 @@
                   :lib artefact-id
                   :version version
                   :basis (b/create-basis {:project (subdir (first lib-paths) "deps.edn")})
-                  :src-dirs src-dirs})
+                  :src-dirs src-dirs
+                  :pom-data [[:licenses
+                              [:license
+                               [:name "Eclipse Public License 1.0"]
+                               [:url "https://opensource.org/license/epl-1-0/"]]]]})
     (b/copy-dir {:src-dirs src-dirs
                  :target-dir class-dir})
     (b/jar {:class-dir class-dir


### PR DESCRIPTION
Without the license in the POM, publishing to clojars fails with the following:
```
Could not transfer metadata is.d0x:cljs-web3-next/maven-metadata.xml from/to clojars (https://clojars.org/repo):
  Authorization failed for https://clojars.org/repo/is/d0x/cljs-web3-next/maven-metadata.xml 403 Forbidden - the POM file does not include a license. See https://bit.ly/3PQunZU
Execution error (AuthorizationException) at org.apache.maven.wagon.shared.http.AbstractHttpClientWagon/put (AbstractHttpClientWagon.java:806).
Authorization failed for https://clojars.org/repo/is/d0x/cljs-web3-next/maven-metadata.xml 403 Forbidden - the POM file does not include a license. See https://bit.ly/3PQunZU
```

Build where it happened: https://app.circleci.com/pipelines/github/district0x/d0x-libs/286/workflows/d236cd4c-0fb1-4b6e-9f3b-7bb280173cfe/jobs/593